### PR TITLE
Remove ngrok from initial apt install

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,8 +14,7 @@ RUN sudo apt install -yq \
         jq \
         jp \
         tree \
-        tldr \
-        ngrok
+        tldr
 
 # add git-lfs and install
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash && \


### PR DESCRIPTION
# Issue

.devcontainer build was failing due to incorrect attempt to install ngrok

# Solution

Remove initial ngrok install and use later official install

## Video or Screenshots

<!-- If you made changes to experience or documentation please include visuals or video to demonstrate the changes -->
