### PR TITLE
Specify explicit make_usable_from_other_demos branch to LLaVA fork clone

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
 echo "Cloning dependent repos..."
 git clone --single-branch https://github.com/mattmazzola/GLIGEN.git
 git clone --single-branch https://github.com/mattmazzola/Segment-Everything-Everywhere-All-At-Once.git SEEM
-git clone --single-branch https://github.com/mattmazzola/LLaVA
+git clone --single-branch -b make_usable_from_other_demos https://github.com/mattmazzola/LLaVA
 git clone --single-branch https://github.com/advimman/lama.git
 
 echo "Creating environments and download pretrained models..."


### PR DESCRIPTION
# Issue

The [mattmazzola/LLaVA](https://github.com/mattmazzola/LLaVA) was forked form original LLaVA and did not have default branch set. Thus when cloned it was copying the `main` branch; however, we should be cloning the [`make_usable_from_other_demos`](https://github.com/mattmazzola/LLaVA/tree/make_usable_from_other_demos) branch

# Solution

Specify the branch in the clone instruction

## Video or Screenshots

<!-- If you made changes to experience or documentation please include visuals or video to demonstrate the changes -->
