### PR TITLE
Add moderation for grounding text input to GLIGEN and generate image output

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,6 +18,9 @@
                 // "input_openai",
                 "output_text_guardlist",
                 "output_text_aics",
+                "gligen_input_text_guardlist",
+                "gligen_input_text_aics",
+                "gligen_output_image_aics",
             ],
             "envFile": "${workspaceFolder}/.env",
             "env": {

--- a/llava_interactive.py
+++ b/llava_interactive.py
@@ -19,6 +19,12 @@ import SEEM.demo_code.app as SEEM  # must import GLIGEN_app before this. Otherwi
 
 sys.path.append(os.path.join(os.environ['LLAVA_INTERACTIVE_HOME'], 'LLaVA'))
 import LLaVA.llava.serve.gradio_web_server as LLAVA
+from LLaVA.llava.utils import (
+    ModerationOptions,
+    does_image_violate_azure_content_safety,
+    does_text_violate_azure_content_safety,
+    violates_guardlist_moderation,
+)
 
 
 class ImageMask(gr.components.Image):
@@ -341,6 +347,23 @@ def get_generated(grounding_text, fix_seed, rand_seed, state):
     if len(grounding_text) == 0:  # mostly user forgot to drag the object and didn't provide grounding text
         raise gr.Error('Please providing grounding text to match the identified object')
 
+    if len(args.moderate) > 0:
+        does_text_violate_policy = False
+
+        if not does_text_violate_policy and (
+            ModerationOptions.ALL.value in args.moderate
+            or ModerationOptions.GLIGEN_INPUT_TEXT_GUARDLIST.value in args.moderate
+        ):
+            does_text_violate_policy |= violates_guardlist_moderation(grounding_text)
+        if not does_text_violate_policy and (
+            ModerationOptions.ALL.value in args.moderate
+            or ModerationOptions.GLIGEN_INPUT_TEXT_AICS.value in args.moderate
+        ):
+            does_text_violate_policy |= does_text_violate_azure_content_safety(grounding_text)
+
+        if does_text_violate_policy:
+            return inpainted_background_img.copy(), state
+
     out_gen_1, _, _, _, state = GLIGEN.generate(
         task='Grounded Inpainting',
         language_instruction='',
@@ -359,7 +382,21 @@ def get_generated(grounding_text, fix_seed, rand_seed, state):
         state=state,
     )
 
-    return out_gen_1['value'], state
+    image = out_gen_1['value']
+
+    if len(args.moderate) > 0:
+        does_image_violate_policy = False
+
+        if not does_image_violate_policy and (
+            ModerationOptions.ALL.value in args.moderate
+            or ModerationOptions.GLIGEN_OUTPUT_IMAGE_AICS.value in args.moderate
+        ):
+            does_image_violate_policy |= does_image_violate_azure_content_safety(image)
+
+        if does_image_violate_policy:
+            return inpainted_background_img.copy(), state
+
+    return image, state
 
 
 def get_generated_full(

--- a/run_demo.sh
+++ b/run_demo.sh
@@ -33,5 +33,14 @@ sleep 10
 conda deactivate; \
 conda activate llava_int; \
 export LLAVA_INTERACTIVE_HOME=.; \
-python llava_interactive.py
+python llava_interactive.py \
+  --moderate \
+  input_text_guardlist \
+  input_text_aics \
+  input_image_aics \
+  output_text_guardlist \
+  output_text_aics \
+  gligen_input_text_guardlist \
+  gligen_input_text_aics \
+  gligen_output_image_aics
 )


### PR DESCRIPTION
# Issue

There was no moderation on the grounding text input to GLIGEN or the image it produced

# Solution

- Add Guardlist and AI CS to input
- Add AICS to GLIGEN output

## Video or Screenshots

<!-- If you made changes to experience or documentation please include visuals or video to demonstrate the changes -->
