### PR TITLE
Add strike through to demo link and add demo removal note to readme to match project page

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 
 *An All-in-One Demo for Image Chat, Segmentation and Generation/Editing.*
 
-[[Project Page](https://llava-vl.github.io/llava-interactive/)] [[Demo](https://llavainteractive.ngrok.app/)] [[Paper](https://arxiv.org/abs/2311.00571)]
+[[Project Page](https://llava-vl.github.io/llava-interactive/)] <s>[Demo]</s> [[Paper](https://arxiv.org/abs/2311.00571)]
+
+> ⚠️ As of Jun 10, 2024 the live demo or playground website is disabled.
 
 <p align="center">
     <img src="https://github.com/LLaVA-VL/llava-interactive/blob/main/images/llava_interactive_logo.png" width="45%">


### PR DESCRIPTION
# Issue

Given #19, it was not clear the demo had been removed intentionally.

# Solution

I made the demo removal warning more noticeable and removed more links to the demo page to reduce confusion.

Fixes #19 

## Video or Screenshots

![image](https://github.com/user-attachments/assets/7e677b01-35ca-4e60-849c-b6a432819e0d)